### PR TITLE
fix newer tasks' image links

### DIFF
--- a/tasks/easy.json
+++ b/tasks/easy.json
@@ -4231,7 +4231,7 @@
         "name": "Get 1 unique from the Hunter Guild",
         "tip": "Received as a drop when completing Hunters Rumours",
         "wikiLink": "https://oldschool.runescape.wiki/w/Hunter_Guild#Other",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Huntsman%27s_kit#/media/File:Huntsman's_kit_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Huntsman's_kit_detail.png/200px-Huntsman's_kit_detail.png",
         "assetImage": "huntsman_kit.png",
         "colLogData": {
             "category": "Other",
@@ -4251,7 +4251,7 @@
         "name": "Get the Sulphur blades",
         "tip": "Received as a drop from sulphur Nagua",
         "wikiLink": "https://oldschool.runescape.wiki/w/Sulphur_Nagua",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Sulphur_blades#/media/File:Sulphur_blades_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Sulphur_blades_detail.png/200px-Sulphur_blades_detail.png",
         "assetImage": "sulphur_blades.png",
         "colLogData": {
             "category": "Other",

--- a/tasks/elite.json
+++ b/tasks/elite.json
@@ -11415,7 +11415,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -11965,7 +11965,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -12515,7 +12515,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -13065,7 +13065,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -13615,7 +13615,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -14165,7 +14165,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -14715,7 +14715,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -15265,7 +15265,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -24514,7 +24514,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -24581,7 +24581,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -24648,7 +24648,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -24715,7 +24715,7 @@
         "name": "Get a teleport anchoring scroll",
         "tip": "Received as drop from Zombie Pirate Locker",
         "wikiLink": "https://oldschool.runescape.wiki/w/Teleport_anchoring_scroll",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Teleport_anchoring_scroll#/media/File:Teleport_anchoring_scroll_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Teleport_anchoring_scroll_detail.png/200px-Teleport_anchoring_scroll_detail.png",
         "assetImage": "teleport_anchoring_scroll.png",
         "colLogData": {
             "category": "Other",
@@ -24734,7 +24734,7 @@
         "name": "Get 1 unique from Fortis Colosseum",
         "tip": "Reward from Fortis Colosseum",
         "wikiLink": "https://oldschool.runescape.wiki/w/Fortis_Colosseum",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Sunfire_splinters#/media/File:Sunfire_splinters_1_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Sunfire_splinters_1_detail.png/200px-Sunfire_splinters_1_detail.png",
         "assetImage": "dizanas_quiver.png",
         "colLogData": {
             "category": "Bosses",
@@ -24773,7 +24773,7 @@
         "name": "Get 1 unique from Fortis Colosseum",
         "tip": "Reward from Fortis Colosseum",
         "wikiLink": "https://oldschool.runescape.wiki/w/Fortis_Colosseum",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Sunfire_splinters#/media/File:Sunfire_splinters_1_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Sunfire_splinters_1_detail.png/200px-Sunfire_splinters_1_detail.png",
         "assetImage": "dizanas_quiver.png",
         "colLogData": {
             "category": "Bosses",
@@ -24812,7 +24812,7 @@
         "name": "Get 1 unique from Fortis Colosseum",
         "tip": "Reward from Fortis Colosseum",
         "wikiLink": "https://oldschool.runescape.wiki/w/Fortis_Colosseum",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Sunfire_splinters#/media/File:Sunfire_splinters_1_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Sunfire_splinters_1_detail.png/200px-Sunfire_splinters_1_detail.png",
         "assetImage": "dizanas_quiver.png",
         "colLogData": {
             "category": "Bosses",
@@ -24851,7 +24851,7 @@
         "name": "Get 1 unique from Tormented Demons",
         "tip": "Can be obtained when killing Tormented Demons",
         "wikiLink": "https://oldschool.runescape.wiki/w/Tormented_demon",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Tormented_synapse#/media/File:Tormented_synapse_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Tormented_synapse_detail.png/200px-Tormented_synapse_detail.png",
         "assetImage": "tormented_synapse.png",
         "colLogData": {
             "category": "Other",
@@ -24878,7 +24878,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -24939,7 +24939,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -25000,7 +25000,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -25061,7 +25061,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -25122,7 +25122,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,

--- a/tasks/hard.json
+++ b/tasks/hard.json
@@ -9155,7 +9155,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -9705,7 +9705,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -10255,7 +10255,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -10805,7 +10805,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -11355,7 +11355,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -11905,7 +11905,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -12455,7 +12455,7 @@
                     "id": 23237,
                     "name": "Berserker necklace ornament kit"
                 },
-                {   "id": 19912, 
+                {   "id": 19912,
                     "name" : "Zombie head (Treasure Trails)"
                 }
             ],
@@ -17841,7 +17841,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -17908,7 +17908,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -17975,7 +17975,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -18042,7 +18042,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -18109,7 +18109,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -18176,7 +18176,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -18243,7 +18243,7 @@
         "name": "Get 1 unique from the Hunter Guild",
         "tip": "Received as a drop when completing Hunters Rumours",
         "wikiLink": "https://oldschool.runescape.wiki/w/Hunter_Guild#Other",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Guild_hunter_top#/media/File:Guild_hunter_top_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Guild_hunter_top_detail.png/200px-Guild_hunter_top_detail.png",
         "assetImage": "guild_hunter_top.png",
         "colLogData": {
             "category": "Other",
@@ -18278,7 +18278,7 @@
         "name": "Get 1 unique from the Hunter Guild",
         "tip": "Received as a drop when completing Hunters Rumours",
         "wikiLink": "https://oldschool.runescape.wiki/w/Hunter_Guild#Other",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Guild_hunter_top#/media/File:Guild_hunter_top_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Guild_hunter_top_detail.png/200px-Guild_hunter_top_detail.png",
         "assetImage": "guild_hunter_top.png",
         "colLogData": {
             "category": "Other",
@@ -18313,7 +18313,7 @@
         "name": "Get 1 unique from the Hunter Guild",
         "tip": "Received as a drop when completing Hunters Rumours",
         "wikiLink": "https://oldschool.runescape.wiki/w/Hunter_Guild#Other",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Guild_hunter_top#/media/File:Guild_hunter_top_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Guild_hunter_top_detail.png/200px-Guild_hunter_top_detail.png",
         "assetImage": "guild_hunter_top.png",
         "colLogData": {
             "category": "Other",
@@ -18367,7 +18367,7 @@
         "name": "Get 1 unique from Tormented Demons",
         "tip": "Can be obtained when killing Tormented Demons",
         "wikiLink": "https://oldschool.runescape.wiki/w/Tormented_demon",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Tormented_synapse#/media/File:Tormented_synapse_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Tormented_synapse_detail.png/200px-Tormented_synapse_detail.png",
         "assetImage": "tormented_synapse.png",
         "colLogData": {
             "category": "Other",
@@ -18394,7 +18394,7 @@
         "name": "Get 1 unique from Tormented Demons",
         "tip": "Can be obtained when killing Tormented Demons",
         "wikiLink": "https://oldschool.runescape.wiki/w/Tormented_demon",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Tormented_synapse#/media/File:Tormented_synapse_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Tormented_synapse_detail.png/200px-Tormented_synapse_detail.png",
         "assetImage": "tormented_synapse.png",
         "colLogData": {
             "category": "Other",
@@ -18421,7 +18421,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -18473,7 +18473,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -18534,7 +18534,7 @@
         "name": "Get 1 unique from Araxxytes/Araxxor",
         "tip": "Can be obtained when killing Araxxytes/Araxxor",
         "wikiLink": "https://oldschool.runescape.wiki/w/Araxxor",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Araxyte_fang#/media/File:Araxyte_fang_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Araxyte_fang_detail.png/200px-Araxyte_fang_detail.png",
         "assetImage": "araxxor_fang.png",
         "colLogData": {
             "category": null,
@@ -18811,7 +18811,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you musat choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -18850,7 +18850,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you musat choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",

--- a/tasks/medium.json
+++ b/tasks/medium.json
@@ -5070,7 +5070,7 @@
         "name": "Get a Scurrius' spine",
         "tip": "Received as a drop when killing Scurrius",
         "wikiLink": "https://oldschool.runescape.wiki/w/Scurrius",
-        "wikiImage": "https://oldschool.runescape.wiki/w/File:Scurrius%27_spine.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Scurrius%27_spine.png/200px-Scurrius%27_spine.png",
         "assetImage": "Scurrius'_spine.png",
         "colLogData": {
             "category": "Bosses",
@@ -5086,7 +5086,7 @@
         "name": "Get 1 unique from Armoured Zombies",
         "tip": "First unique is Defender of Varrock for Broken zombie axe, and 2nd unique is completing Curse of Arrav for the helmet",
         "wikiLink": "https://oldschool.runescape.wiki/w/Armoured_zombie_(Zemouregal%27s_Fort)",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Broken_zombie_axe_detail.png/200px-Broken_zombie_axe_detail.png",
         "assetImage": "Broken_zombie_axe.png",
         "colLogData": {
             "category": "Other",
@@ -5103,7 +5103,7 @@
         "name": "Get 1 unique from Armoured Zombies",
         "tip": "First unique is Defender of Varrock for Broken zombie axe, and 2nd unique is completing Curse of Arrav for the helmet",
         "wikiLink": "https://oldschool.runescape.wiki/w/Armoured_zombie_(Zemouregal%27s_Fort)",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Broken_zombie_axe_detail.png/200px-Broken_zombie_axe_detail.png",
         "assetImage": "Broken_zombie_axe.png",
         "colLogData": {
             "category": "Other",
@@ -5120,7 +5120,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -5148,7 +5148,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -5176,7 +5176,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -5204,7 +5204,7 @@
         "name": "Get 1 unique from Moons of Peril",
         "tip": "Received as a drop from Moons of Peril bosses",
         "wikiLink": "https://oldschool.runescape.wiki/w/Moons_of_Peril",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Dual_macuahuitl#/media/File:Dual_macuahuitl_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Dual_macuahuitl_detail.png/200px-Dual_macuahuitl_detail.png",
         "assetImage": "dual_macuahuitl.png",
         "colLogData": {
             "category": "Bosses",
@@ -5232,7 +5232,7 @@
         "name": "Get 1 unique from the Hunter Guild",
         "tip": "Received as a drop when completing Hunters Rumours",
         "wikiLink": "https://oldschool.runescape.wiki/w/Hunter_Guild#Other",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Guild_hunter_top#/media/File:Guild_hunter_top_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Guild_hunter_top_detail.png/200px-Guild_hunter_top_detail.png",
         "assetImage": "guild_hunter_top.png",
         "colLogData": {
             "category": "Other",
@@ -5268,7 +5268,7 @@
         "name": "Get 1 Alchemist outfit piece",
         "tip": "Obtained through Mastering Mixology Herblore Minigame",
         "wikiLink": "https://oldschool.runescape.wiki/w/Mastering_Mixology",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Alchemist_labcoat#/media/File:Alchemist_labcoat_(apron_off)_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Alchemist_labcoat_(apron_off)_detail.png/200px-Alchemist_labcoat_(apron_off)_detail.png",
         "assetImage": "Alchemist_labcoat.png",
         "colLogData": {
             "category": "Minigames",
@@ -5286,7 +5286,7 @@
         "name": "Get 1 Alchemist outfit piece",
         "tip": "Obtained through Mastering Mixology Herblore Minigame",
         "wikiLink": "https://oldschool.runescape.wiki/w/Mastering_Mixology",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Alchemist_labcoat#/media/File:Alchemist_labcoat_(apron_off)_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Alchemist_labcoat_(apron_off)_detail.png/200px-Alchemist_labcoat_(apron_off)_detail.png",
         "assetImage": "Alchemist_labcoat.png",
         "colLogData": {
             "category": "Minigames",
@@ -5304,7 +5304,7 @@
         "name": "Get 1 Alchemist outfit piece",
         "tip": "Obtained through Mastering Mixology Herblore Minigame",
         "wikiLink": "https://oldschool.runescape.wiki/w/Mastering_Mixology",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Alchemist_labcoat#/media/File:Alchemist_labcoat_(apron_off)_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Alchemist_labcoat_(apron_off)_detail.png/200px-Alchemist_labcoat_(apron_off)_detail.png",
         "assetImage": "Alchemist_labcoat.png",
         "colLogData": {
             "category": "Minigames",
@@ -5322,7 +5322,7 @@
         "name": "Get 1 unique from Amoxliatl",
         "tip": "Obtained when killing Amoxliatl. Taskers may also kill Frost naguas as they drop the same uniques excluding the pet",
         "wikiLink": "https://oldschool.runescape.wiki/w/Amoxliatl",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Glacial_temotli#/media/File:Glacial_temotli_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Glacial_temotli_detail.png/200px-Glacial_temotli_detail.png",
         "assetImage": "Glacial_temotli_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5340,7 +5340,7 @@
         "name": "Get 1 unique from Amoxliatl",
         "tip": "Obtained when killing Amoxliatl. Taskers may also kill Frost naguas as they drop the same uniques excluding the pet",
         "wikiLink": "https://oldschool.runescape.wiki/w/Amoxliatl",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Glacial_temotli#/media/File:Glacial_temotli_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Glacial_temotli_detail.png/200px-Glacial_temotli_detail.png",
         "assetImage": "Glacial_temotli_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5358,7 +5358,7 @@
         "name": "Get 1 unique from Amoxliatl",
         "tip": "Obtained when killing Amoxliatl. Taskers may also kill Frost naguas as they drop the same uniques excluding the pet",
         "wikiLink": "https://oldschool.runescape.wiki/w/Amoxliatl",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Glacial_temotli#/media/File:Glacial_temotli_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Glacial_temotli_detail.png/200px-Glacial_temotli_detail.png",
         "assetImage": "Glacial_temotli_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5376,7 +5376,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you must choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5397,7 +5397,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you must choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5418,7 +5418,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you must choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",
@@ -5439,7 +5439,7 @@
         "name": "Get 1 unique from Royal Titans",
         "tip": "Obtained by killing the Royal Titans boss. First kill you must choose Take Pages option as you can force this unique.",
         "wikiLink": "https://oldschool.runescape.wiki/w/Royal_Titans",
-        "wikiImage": "https://oldschool.runescape.wiki/w/Twinflame_staff#/media/File:Twinflame_staff_detail.png",
+        "wikiImage": "https://oldschool.runescape.wiki/images/thumb/Twinflame_staff_detail.png/200px-Twinflame_staff_detail.png",
         "assetImage": "Twinflame_staff_detail.png",
         "colLogData": {
             "category": "Bosses",

--- a/tasks/medium.json
+++ b/tasks/medium.json
@@ -5085,7 +5085,7 @@
         "_id": 165,
         "name": "Get 1 unique from Armoured Zombies",
         "tip": "First unique is Defender of Varrock for Broken zombie axe, and 2nd unique is completing Curse of Arrav for the helmet",
-        "wikiLink": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
+        "wikiLink": "https://oldschool.runescape.wiki/w/Armoured_zombie_(Zemouregal%27s_Fort)",
         "wikiImage": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
         "assetImage": "Broken_zombie_axe.png",
         "colLogData": {
@@ -5102,7 +5102,7 @@
         "_id": 166,
         "name": "Get 1 unique from Armoured Zombies",
         "tip": "First unique is Defender of Varrock for Broken zombie axe, and 2nd unique is completing Curse of Arrav for the helmet",
-        "wikiLink": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
+        "wikiLink": "https://oldschool.runescape.wiki/w/Armoured_zombie_(Zemouregal%27s_Fort)",
         "wikiImage": "https://oldschool.runescape.wiki/w/Broken_zombie_axe#/media/File:Broken_zombie_axe_detail.png",
         "assetImage": "Broken_zombie_axe.png",
         "colLogData": {


### PR DESCRIPTION
A few people mentioned on the CC that some of the newer tasks were not properly displaying the images in the RuneLite plugin. It seems that for those, the link to the Wiki _Page_ was used instead of the direct image link.

I've ran a regex to fix all links using a default image size of 200px, since that's a least 8x as big as the usual size it is displayed, but also relatively small to reduce bandwidth when possible.

Also fixed the wiki link to the armoured zombies task which I noticed was the same as the image one.